### PR TITLE
refactor: remove append_entries, snapshot and vote relevant items

### DIFF
--- a/src/message.proto
+++ b/src/message.proto
@@ -23,48 +23,6 @@ message FetchClusterResponse {
     uint64 term = 3;
 }
 
-message AppendEntriesRequest {
-    uint64 term = 1;
-    uint64 leader_id = 2;
-    uint64 prev_log_index = 3;
-    uint64 prev_log_term = 4;
-    repeated bytes entries = 5;
-    uint64 leader_commit = 6;
-}
-
-message AppendEntriesResponse {
-    uint64 term = 1;
-    bool success = 2;
-    uint64 hint_index = 3;
-}
-
-message VoteRequest {
-    uint64 term = 1;
-    uint64 candidate_id = 2;
-    uint64 last_log_index = 3;
-    uint64 last_log_term = 4;
-}
-
-message VoteResponse {
-    uint64 term = 1;
-    bool vote_granted = 2;
-    repeated bytes spec_pool = 3;
-}
-
-message InstallSnapshotRequest {
-    uint64 term = 1;
-    uint64 leader_id = 2;
-    uint64 last_included_index = 3;
-    uint64 last_included_term = 4;
-    uint64 offset = 5;
-    bytes data = 6;
-    bool done = 7;
-}
-
-message InstallSnapshotResponse {
-    uint64 term = 1;
-}
-
 message IdSet {
     repeated bytes ids = 1;
 }
@@ -96,10 +54,6 @@ service Protocol {
     rpc WaitSynced(commandpb.WaitSyncedRequest)
         returns (commandpb.WaitSyncedResponse);
     rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
-    rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse);
-    rpc Vote(VoteRequest) returns (VoteResponse);
-    rpc InstallSnapshot(stream InstallSnapshotRequest)
-        returns (InstallSnapshotResponse);
     rpc FetchLeader(FetchLeaderRequest) returns (FetchLeaderResponse);
     rpc FetchCluster(FetchClusterRequest) returns (FetchClusterResponse);
     rpc FetchReadState(FetchReadStateRequest) returns (FetchReadStateResponse);


### PR DESCRIPTION
The reason for extracting curp-proto as a separate repository is to share protobuf definitions between Xline and SDKs implemented in different languages. However, within the `message.proto` file, there are some RPC methods that the client SDK does not need to be concerned with, such as `append_entries`, `vote`, and `snapshot`. This PR will remove these RPC methods.