### PR TITLE
refactor: remove error from ShutdownResponse

### DIFF
--- a/src/message.proto
+++ b/src/message.proto
@@ -44,9 +44,6 @@ message ShutdownRequest {
 }
 
 message ShutdownResponse {
-    optional uint64 leader_id = 1;
-    uint64 term = 2;
-    optional errorpb.ProposeError error = 3;
 }
 
 message ProposeConfChangeRequest {


### PR DESCRIPTION
Thanks to the refactor error-handling logic in Xline, we don't need the error information in ShutdownResponse. Therefore, this pr will remove the error from the `ShutdownResponse`. 

FYI: 
[Refactor/error handling curp and client](https://github.com/xline-kv/Xline/pull/480)
[Refactor the error-handling logic of Xline](https://github.com/xline-kv/Xline/issues/463)

PS: This pr should be merged after [the pr](https://github.com/xline-kv/Xline/pull/480) being merged